### PR TITLE
Update Crc32Test.php

### DIFF
--- a/test/Horde/Stream/Filter/Crc32Test.php
+++ b/test/Horde/Stream/Filter/Crc32Test.php
@@ -34,7 +34,7 @@ class Horde_Stream_Filter_Crc32Test extends \PHPUnit\Framework\TestCase
         rewind($this->fp);
         while (fread($this->fp, 1024)) {}
 
-        $this->assertObjectHasAttribute('crc32', $params);
+        $this->assertObjectHasProperty('crc32', $params);
 
         $this->assertEquals(
             crc32($this->testdata),


### PR DESCRIPTION
```
assertObjectHasAttribute() is deprecated and will be removed in PHPUnit 10. Refactor your test to use assertObjectHasProperty() instead.
```